### PR TITLE
Agregar acuerdo de asistencias

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ No. de Versión | Cambio | Autor | Aprobado | Fecha de cambio
 
 
   ## General
-  * #### [Asistencias](https://drive.google.com/open?id=1-PlNH_aFjIOZEFwT5u8G7qJLZWaiHsBdNgrNcYpM8NI):
-    Lista de asistencias para los módulos de clases en el semestre i.
+  
+  * #### Asistencias:
+    [Lista](https://drive.google.com/open?id=1-PlNH_aFjIOZEFwT5u8G7qJLZWaiHsBdNgrNcYpM8NI) de asistencias para los módulos de clases en el semestre i. 
+    [Acuerdo](https://github.com/CaveLabs-1/Wiki/blob/master/Acuerdo%20de%20asistencias.pdf) del departamento con respecto a las asistencias a los módulos de clase.
   * #### [Auditorías](https://github.com/CaveLabs-1/Wiki/blob/master/Auditorias.md):
     Lista de todos los resultados de las auditorias realizadas por el departamento
   * #### [CaveLabs Academy](https://github.com/CaveLabs-1/Wiki/blob/master/Academy.md):


### PR DESCRIPTION
Se creó el acuerdo y era necesario documentarlo en la wiki.