### PR TITLE
Cambiar redacción métricas

### DIFF
--- a/Configuracion/Procesos/Proceso Cambios.md
+++ b/Configuracion/Procesos/Proceso Cambios.md
@@ -30,6 +30,6 @@ No. de versión | Cambio | Autor | Aprobado | Fecha de Cambio
 1 | Creación | Mariana | Mauricio Hernandez | 7 Feb 2018
 1.1 | Modificación | Mariana | |13 Mar 2018
 1.2 | Agregar fase análisis | Mariana | Valter Núñez | 18 Abr 2018
-1.3 | Modificar redacción de métricas | Mariana  | | 20 Abr 2018
+1.3 | Modificar redacción de métricas | Mariana  | Valter Núñez | 20 Abr 2018
 
 Última edición: @pirty6 abril 20, 2018.

--- a/Configuracion/Procesos/Proceso Cambios.md
+++ b/Configuracion/Procesos/Proceso Cambios.md
@@ -1,11 +1,11 @@
 # Proceso para Cambiar elementos de configuración
-Versión 1.2
+Versión 1.3
 
 
 []() | []()  
 --|--
 Objetivo| Actualizar la versión de un elemento de la línea base
-Métricas utilizadas | Número de Errores / Tiempo en el que se realiza la auditoría
+Métricas utilizadas | Número de Errores / Número de días desde la última auditoría
 Repositorio de Métricas | Carpeta Auditorías encontrada en el root de la wiki
 Criterios de entrada | Elemento de configuración
 Definir políticas y estándares | Gitflow
@@ -30,5 +30,6 @@ No. de versión | Cambio | Autor | Aprobado | Fecha de Cambio
 1 | Creación | Mariana | Mauricio Hernandez | 7 Feb 2018
 1.1 | Modificación | Mariana | |13 Mar 2018
 1.2 | Agregar fase análisis | Mariana | Valter Núñez | 18 Abr 2018
+1.3 | Modificar redacción de métricas | Mariana  | | 20 Abr 2018
 
-Última edición: @pirty6 abril 18, 2018.
+Última edición: @pirty6 abril 20, 2018.


### PR DESCRIPTION
Se cambió la redacción de las métricas ya que ocasionaba ambigüedad en los integrantes del departamento